### PR TITLE
Fix error on extend video count >1

### DIFF
--- a/custom_nodes.py
+++ b/custom_nodes.py
@@ -651,20 +651,19 @@ class WanVideoSampler_F2:
         return (full_sigmas, high_sigmas, low_sigmas)
     
     def process(
-            self,
-            model,
-            seed,
-            sampler,
-            scheduler,
-            denoised_output,
-            vae_decode_type,
-            vae_tile_size,
-            preview_resolution,
-            unload_all_models,
-            start_image=None,
-            end_image=None,
-        ):
-
+    self,
+    model,
+    seed,
+    sampler,
+    scheduler,
+    denoised_output,
+    vae_decode_type,
+    vae_tile_size,
+    preview_resolution,
+    unload_all_models,
+    start_image=None,
+    end_image=None,
+    ):
         args = {
             "model": model,
             "seed": seed,
@@ -701,8 +700,7 @@ class WanVideoSampler_F2:
         args["fun_inpaint"] = fun_inpaint
 
         if image_to_video and config.extend_video_count > 1:
-
-            new_images = torch.empty(config.extend_video_count * 49, height, width, 3)
+            all_images = []
 
             images = None
             for i in range(config.extend_video_count):
@@ -711,11 +709,13 @@ class WanVideoSampler_F2:
                     args["end_image"] = None
 
                 images = self.sampling(**args)
-                new_images[i * 49:(i + 1) * 49] = images
+                all_images.append(images)
+
+            new_images = torch.cat(all_images, dim=0)
         else:
             new_images = self.sampling(**args)
-        
-        return (new_images, )
+
+        return (new_images,)
 
 
     def sampling(self, **kwargs):


### PR DESCRIPTION
The `process` function in `custom_nodes.py` assumes a fixed batch size of 49 frames, causing a tensor size mismatch error when the duration is set to 65 frames (or any other value). This results in the error `RuntimeError: Extended tensor size (49) must match current size (65)`.

The `process` function has been modified to dynamically handle the number of frames returned by `self.sampling`. The fixed batch size of 49 has been removed and a list is used to collect frame batches, which has then been merged with `torch.cat`. This ensures compatibility with any duration setting and `extend_video_count > 1`.

The fix has been verified using a 65-frame duration setting and different `extend_video_count` values ​​in ComfyUI. The error no longer occurs, and the resulting tensor now has the correct shape.